### PR TITLE
Add fb events

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -7,6 +7,6 @@
 {{ partial "homepage/blog_latest" . }}
 
 <!-- Gcal -->
-{{ partial "google-calendar" }}
+{{ partial "calendar" }}
 
 {{ end }}

--- a/site/layouts/partials/calendar.html
+++ b/site/layouts/partials/calendar.html
@@ -1,14 +1,14 @@
 <!-- FB Code -->
 <div id="fb-root"></div>
 <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.3"></script>
-<!-- FB Events -->
-<div class="fb-page" data-href="https://www.facebook.com/centrecodsa" data-tabs="events" data-width="500" data-height="" data-small-header="true" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="false"><blockquote cite="https://www.facebook.com/centrecodsa" class="fb-xfbml-parse-ignore"><a href="https://www.facebook.com/centrecodsa">Centre County DSA</a></blockquote></div>
 
 <div class="bg-off-white pv4">
 	<div class="ph3 mw7 center">
 
 		<h2 class="f2 b lh-title mb3">Calendar of Events</h2>
-        
+        <!-- FB Events -->
+	<div class="fb-page" data-href="https://www.facebook.com/centrecodsa" data-tabs="events" data-width="500" data-height="" data-small-header="true" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="false"><blockquote cite="https://www.facebook.com/centrecodsa" class="fb-xfbml-parse-ignore"><a href="https://www.facebook.com/centrecodsa">Centre County DSA</a></blockquote></div>
+	</br>
         <iframe src="https://calendar.google.com/calendar/embed?showPrint=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=7ocdia3ats45mmg6lg1t12rhis%40group.calendar.google.com&amp;color=%235229A3&amp;ctz=America%2FNew_York" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 
 	</div>

--- a/site/layouts/partials/calendar.html
+++ b/site/layouts/partials/calendar.html
@@ -1,0 +1,15 @@
+<!-- FB Code -->
+<div id="fb-root"></div>
+<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.3"></script>
+<!-- FB Events -->
+<div class="fb-page" data-href="https://www.facebook.com/centrecodsa" data-tabs="events" data-width="500" data-height="" data-small-header="true" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="false"><blockquote cite="https://www.facebook.com/centrecodsa" class="fb-xfbml-parse-ignore"><a href="https://www.facebook.com/centrecodsa">Centre County DSA</a></blockquote></div>
+
+<div class="bg-off-white pv4">
+	<div class="ph3 mw7 center">
+
+		<h2 class="f2 b lh-title mb3">Calendar of Events</h2>
+        
+        <iframe src="https://calendar.google.com/calendar/embed?showPrint=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=7ocdia3ats45mmg6lg1t12rhis%40group.calendar.google.com&amp;color=%235229A3&amp;ctz=America%2FNew_York" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+	</div>
+</div>

--- a/site/layouts/partials/google-calendar.html
+++ b/site/layouts/partials/google-calendar.html
@@ -1,9 +1,0 @@
-<div class="bg-off-white pv4">
-	<div class="ph3 mw7 center">
-
-		<h2 class="f2 b lh-title mb3">Calendar of Events</h2>
-        
-        <iframe src="https://calendar.google.com/calendar/embed?showPrint=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=7ocdia3ats45mmg6lg1t12rhis%40group.calendar.google.com&amp;color=%235229A3&amp;ctz=America%2FNew_York" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-
-	</div>
-</div>

--- a/site/layouts/section/get_involved.html
+++ b/site/layouts/section/get_involved.html
@@ -46,6 +46,6 @@
 </div>
 
 <!-- Gcal -->
-{{ partial "google-calendar" (dict )}}
+{{ partial "calendar" (dict )}}
 
 {{end}}


### PR DESCRIPTION
Rename the 'google-calendar' partial to 'calendar' and add it above the google calendar (which may be removed later).